### PR TITLE
pool.execute params should be none by default

### DIFF
--- a/tornado_mysql/pools.py
+++ b/tornado_mysql/pools.py
@@ -80,7 +80,7 @@ class Pool(object):
         self._opened_conns -= 1
 
     @coroutine
-    def execute(self, query, params):
+    def execute(self, query, params=None):
         """Execute query in pool.
 
         Returns future yielding closed cursor.


### PR DESCRIPTION
Hello,

I think that pool.execute params should be none by default like cursor.execute is.

Lionel
