### PR TITLE
Create raise error when settings charset not in charsets

### DIFF
--- a/tornado_mysql/connections.py
+++ b/tornado_mysql/connections.py
@@ -591,7 +591,10 @@ class Connection(object):
         if use_unicode is not None:
             self.use_unicode = use_unicode
 
-        self.encoding = charset_by_name(self.charset).encoding
+        if charset_by_name(self.charset):
+            self.encoding = charset_by_name(self.charset).encoding
+        else:
+            raise ValueError('Charset %s not in charsets' % self.charset)
 
         client_flag |= CLIENT.CAPABILITIES | CLIENT.MULTI_STATEMENTS
         if self.db:


### PR DESCRIPTION
Hi when i try insert to db, i have AttributeError: NoneType object has no attribute ''encoding'. My wrong was i use 'utf-8' instead 'utf8'. AttributeError not full information error and i make simple modifications
