### PR TITLE
Fixed `LOAD DATA LOCAL INFILE` commands

### DIFF
--- a/tornado_mysql/tests/__init__.py
+++ b/tornado_mysql/tests/__init__.py
@@ -1,5 +1,6 @@
 from tornado_mysql.tests.test_issues import *
 from tornado_mysql.tests.test_basic import *
+from tornado_mysql.tests.test_load_local import *
 from tornado_mysql.tests.test_nextset import *
 from tornado_mysql.tests.test_DictCursor import *
 from tornado_mysql.tests.test_connection import TestConnection

--- a/tornado_mysql/tests/test_load_local.py
+++ b/tornado_mysql/tests/test_load_local.py
@@ -1,5 +1,6 @@
-from pymysql import OperationalError, Warning
-from pymysql.tests import base
+from tornado.testing import gen_test
+from tornado_mysql.err import OperationalError, Warning
+from tornado_mysql.tests import base
 
 import os
 import warnings
@@ -8,59 +9,68 @@ __all__ = ["TestLoadLocal"]
 
 
 class TestLoadLocal(base.PyMySQLTestCase):
+    @gen_test
     def test_no_file(self):
         """Test load local infile when the file does not exist"""
         conn = self.connections[0]
         c = conn.cursor()
-        c.execute("CREATE TABLE test_load_local (a INTEGER, b INTEGER)")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            yield c.execute("DROP TABLE IF EXISTS test_load_local")
+        yield c.execute("CREATE TABLE test_load_local (a INTEGER, b INTEGER)")
         try:
-            self.assertRaises(
-                OperationalError,
-                c.execute,
-                ("LOAD DATA LOCAL INFILE 'no_data.txt' INTO TABLE "
-                 "test_load_local fields terminated by ','")
-            )
+            with self.assertRaises(OperationalError) as cm:
+                yield c.execute(
+                    "LOAD DATA LOCAL INFILE 'no_data.txt' INTO TABLE "
+                    "test_load_local fields terminated by ','")
         finally:
-            c.execute("DROP TABLE test_load_local")
+            yield c.execute("DROP TABLE IF EXISTS test_load_local")
             c.close()
-
+    @gen_test
     def test_load_file(self):
         """Test load local infile with a valid file"""
         conn = self.connections[0]
         c = conn.cursor()
-        c.execute("CREATE TABLE test_load_local (a INTEGER, b INTEGER)")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            yield c.execute("DROP TABLE IF EXISTS test_load_local")
+        yield c.execute("CREATE TABLE test_load_local (a INTEGER, b INTEGER)")
         filename = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                 'data',
                                 'load_local_data.txt')
         try:
-            c.execute(
+            yield c.execute(
                 ("LOAD DATA LOCAL INFILE '{0}' INTO TABLE " +
                  "test_load_local FIELDS TERMINATED BY ','").format(filename)
             )
-            c.execute("SELECT COUNT(*) FROM test_load_local")
+            yield c.execute("SELECT COUNT(*) FROM test_load_local")
             self.assertEqual(22749, c.fetchone()[0])
         finally:
-            c.execute("DROP TABLE test_load_local")
+            yield c.execute("DROP TABLE IF EXISTS test_load_local")
 
+    @gen_test
     def test_load_warnings(self):
         """Test load local infile produces the appropriate warnings"""
         conn = self.connections[0]
         c = conn.cursor()
-        c.execute("CREATE TABLE test_load_local (a INTEGER, b INTEGER)")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            yield c.execute("DROP TABLE IF EXISTS test_load_local")
+        yield c.execute("CREATE TABLE test_load_local (a INTEGER, b INTEGER)")
         filename = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                 'data',
                                 'load_local_warn_data.txt')
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
-                c.execute(
+                yield c.execute(
                     ("LOAD DATA LOCAL INFILE '{0}' INTO TABLE " +
                      "test_load_local FIELDS TERMINATED BY ','").format(filename)
                 )
                 self.assertEqual(w[0].category, Warning)
                 self.assertTrue("Incorrect integer value" in str(w[-1].message))
         finally:
-            c.execute("DROP TABLE test_load_local")
+            yield c.execute("DROP TABLE IF EXISTS test_load_local")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Fixes for both "buffered" & "unbuffered" cursor types
* Registered `test_load_local` to run with tests
* Refactored `test_load_local` tests to work with the tornado framework

More information here:
https://github.com/PyMySQL/Tornado-MySQL/issues/29