### PR TITLE
[bugfix] round datetimes to the nearest full microsecond

### DIFF
--- a/tornado_mysql/converters.py
+++ b/tornado_mysql/converters.py
@@ -123,7 +123,7 @@ def convert_datetime(obj):
         usecs = '0'
         if '.' in hms:
             hms, usecs = hms.split('.')
-        usecs = float('0.' + usecs) * 1e6
+        usecs = round(float('0.' + usecs) * 1e6)
         return datetime.datetime(*[ int(x) for x in ymd.split('-')+hms.split(':')+[usecs] ])
     except ValueError:
         return convert_date(obj)


### PR DESCRIPTION
After we convert the microseconds string to a float and multiply by `1e6`, it's possible that we lose a microsecond when casting to an integer again:

Example:

```
In [1]: usecs = float('0.524226') * 1e6

In [2]: usecs
Out[2]: 524225.99999999994

In [3]: int(usecs)
Out[3]: 524225
```

Test code:

```
old_errors = 0
new_errors = 0

for expected in range(1000000):
    usecs_string = '0.' + str(expected).zfill(6)

    usecs = float(usecs_string) * 1e6

    old_actual = int(usecs)
    new_actual = int(round(usecs))

    if old_actual != expected:
        old_errors += 1

    if new_actual != expected:
        new_errors += 1


print 'old_errors: ' + str(old_errors)
print 'new_errors: ' + str(new_errors)
```
Test output:

```
old_errors: 11549
new_errors: 0
```